### PR TITLE
Fixed build error on osx.

### DIFF
--- a/makefile.osx
+++ b/makefile.osx
@@ -40,6 +40,7 @@ $(SONAME): $(SOL_SRC)
 	@$(CXX) --version	
 	@echo "=============================="
 	@mkdir -p $(LIB_DIR)
+	@mkdir -p $(BUILD_DIR)
 	@cp $(SOLCLIENT_DIR)/lib.osx/libcrypto.a             $(LIB_DIR)
 	@cp $(SOLCLIENT_DIR)/lib.osx/libsolclient.1.dylib    $(LIB_DIR)
 	@cp $(SOLCLIENT_DIR)/lib.osx/libsolclient.a          $(LIB_DIR)


### PR DESCRIPTION
Error Message
```
==============================
Apple clang version 12.0.5 (clang-1205.0.22.11)
Target: x86_64-apple-darwin20.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
Apple clang version 12.0.5 (clang-1205.0.22.11)
Target: x86_64-apple-darwin20.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
==============================
.
.
.
.
ld: can't open output file for writing: /Users/stevelo/solace-go/bin/direct.test.osx, errno=2 for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```